### PR TITLE
feat: add /healthcheck endpoint for external monitoring

### DIFF
--- a/internal/model/installed_app.go
+++ b/internal/model/installed_app.go
@@ -86,3 +86,16 @@ func (t InstalledApp) NeedRefresh(advanceDays int) bool {
 func (t InstalledApp) IsAccountInvalid() bool {
 	return t.RefreshedError == RefreshedErrorInvalidAccount
 }
+
+// IsExpired checks if the app has strictly expired (ExpirationDate < now)
+func (t InstalledApp) IsExpired() bool {
+	now := time.Now()
+
+	// If ExpirationDate is nil, the app is considered expired (never refreshed or unknown expiration)
+	if t.ExpirationDate == nil {
+		return true
+	}
+
+	// Strict check: expired if ExpirationDate is before now
+	return t.ExpirationDate.Before(now)
+}

--- a/internal/service/db.go
+++ b/internal/service/db.go
@@ -49,6 +49,22 @@ func GetEnableAppListByUDID(udid string) ([]model.InstalledApp, error) {
 	return apps, nil
 }
 
+// HasExpiredApps checks if there are any enabled apps that have expired
+func HasExpiredApps() (bool, error) {
+	var apps []model.InstalledApp
+	if result := db.Store().Where("enabled = ?", true).Find(&apps); result.Error != nil {
+		return false, result.Error
+	}
+
+	for _, app := range apps {
+		if app.IsExpired() {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 func SaveApp(app model.InstalledApp) (*model.InstalledApp, error) {
 	// 查找之前的安装记录，存在记录直接更新旧的
 	var cur model.InstalledApp


### PR DESCRIPTION
## Summary

This PR adds a health check endpoint at `/healthcheck` (no `/api` prefix) to enable integration with external monitoring services like healthchecks.io and Uptime-kuma.

## Changes

### New Endpoint
- **URL**: `GET /healthcheck`
- **Behavior**:
  - Returns HTTP 200 when all enabled apps are healthy (not expired)
  - Returns HTTP 503 when any enabled apps have expired

### Implementation Details
- Added `IsExpired()` method to `InstalledApp` model for strict expiration check (`ExpirationDate < now`)
- Added `HasExpiredApps()` function in service layer to check for expired apps
- Endpoint returns simple status response without exposing sensitive app details

## Use Cases

Users can now configure external monitoring services:
- **healthchecks.io**: Set up a check with the `/healthcheck` URL
- **Uptime-kuma**: Add HTTP monitor expecting status code 200
- **Kubernetes**: Use as liveness/readiness probe

When sideloaded apps expire and need refreshing, the endpoint returns 503, triggering alerts from the monitoring service.

## Related Issue

Closes #75 (Support success webhooks/alerts - enables watchdog heartbeat functionality)