### PR TITLE
Stop using refresh mode for new install tasks

### DIFF
--- a/internal/manager/install_manager.go
+++ b/internal/manager/install_manager.go
@@ -146,8 +146,7 @@ func (t *InstallManager) Start(ctx context.Context, opts InstallOptions) error {
 
 func buildInstallArgs(opts InstallOptions, provisionPath string) []string {
 	if opts.IP != "" && opts.Port != 0 && opts.UDID != "" {
-		pairingFile := filepath.Join(app.RemotePairingDir(), opts.UDID+".plist")
-		return []string{"sign-rsd", "--apple-id", "--register-and-install", "--output-provision", provisionPath, "--ip", opts.IP, "--port", fmt.Sprintf("%d", opts.Port), "--pairing-file", pairingFile, "-u", opts.Account, "-p", opts.IpaPath}
+		return []string{"sign-rsd", "--apple-id", "--register-and-install", "--output-provision", provisionPath, "--ip", opts.IP, "--port", fmt.Sprintf("%d", opts.Port), "--udid", opts.UDID, "-u", opts.Account, "-p", opts.IpaPath}
 	}
 
 	return []string{"sign", "--apple-id", "--register-and-install", "--output-provision", provisionPath, "--udid", opts.UDID, "-u", opts.Account, "-p", opts.IpaPath}

--- a/internal/manager/install_manager.go
+++ b/internal/manager/install_manager.go
@@ -83,8 +83,8 @@ func (t *InstallManager) TryStart(ctx context.Context, opts InstallOptions) erro
 func (t *InstallManager) Start(ctx context.Context, opts InstallOptions) error {
 	t.outputStdout.Reset()
 
-	// set execute timeout 30 miniutes
-	timeout := 30 * time.Minute
+	// Large tvOS apps can take longer than 30 minutes to sign and install.
+	timeout := 60 * time.Minute
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	t.cancel = cancel
 
@@ -99,10 +99,7 @@ func (t *InstallManager) Start(ctx context.Context, opts InstallOptions) error {
 		return fmt.Errorf("afc service not available: %w", err)
 	}
 
-	args := []string{"sign", "--apple-id", "--register-and-install", "--output-provision", provisionPath, "--udid", opts.UDID, "-u", opts.Account, "-p", opts.IpaPath}
-	if opts.IP != "" && opts.Port != 0 && opts.UDID != "" {
-		args = []string{"sign-rsd", "--apple-id", "--register-and-install", "--output-provision", provisionPath, "--ip", opts.IP, "--port", fmt.Sprintf("%d", opts.Port), "--udid", opts.UDID, "-u", opts.Account, "-p", opts.IpaPath}
-	}
+	args := buildInstallArgs(opts, provisionPath)
 	if opts.RemoveExtensions {
 		args = append(args, "--remove-extensions")
 	}
@@ -145,6 +142,15 @@ func (t *InstallManager) Start(ctx context.Context, opts InstallOptions) error {
 	}
 
 	return nil
+}
+
+func buildInstallArgs(opts InstallOptions, provisionPath string) []string {
+	if opts.IP != "" && opts.Port != 0 && opts.UDID != "" {
+		pairingFile := filepath.Join(app.RemotePairingDir(), opts.UDID+".plist")
+		return []string{"sign-rsd", "--apple-id", "--register-and-install", "--output-provision", provisionPath, "--ip", opts.IP, "--port", fmt.Sprintf("%d", opts.Port), "--pairing-file", pairingFile, "-u", opts.Account, "-p", opts.IpaPath}
+	}
+
+	return []string{"sign", "--apple-id", "--register-and-install", "--output-provision", provisionPath, "--udid", opts.UDID, "-u", opts.Account, "-p", opts.IpaPath}
 }
 
 func (t *InstallManager) GetMobileProvisionPath() string {

--- a/internal/manager/install_manager_test.go
+++ b/internal/manager/install_manager_test.go
@@ -1,0 +1,48 @@
+package manager
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildInstallArgsUsesPairingFileForRSD(t *testing.T) {
+	t.Setenv("HOME", "/tmp/atvloadly-test-home")
+
+	args := buildInstallArgs(InstallOptions{
+		UDID:    "test-device-udid",
+		IP:      "192.0.2.10",
+		Port:    49152,
+		Account: "user@example.com",
+		IpaPath: "app.ipa",
+	}, "embedded.mobileprovision")
+
+	if args[0] != "sign-rsd" {
+		t.Fatalf("expected sign-rsd command, got %q", args[0])
+	}
+	if containsArg(args, "--udid") {
+		t.Fatal("sign-rsd does not accept --udid")
+	}
+
+	pairingFlag := indexArg(args, "--pairing-file")
+	if pairingFlag == -1 || pairingFlag+1 >= len(args) {
+		t.Fatal("expected --pairing-file argument")
+	}
+
+	wantPairingFile := filepath.Join("/tmp/atvloadly-test-home", ".config/PlumeImpactor/pairing_files/test-device-udid.plist")
+	if args[pairingFlag+1] != wantPairingFile {
+		t.Fatalf("pairing file = %q, want %q", args[pairingFlag+1], wantPairingFile)
+	}
+}
+
+func containsArg(args []string, want string) bool {
+	return indexArg(args, want) != -1
+}
+
+func indexArg(args []string, want string) int {
+	for i, arg := range args {
+		if arg == want {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -398,7 +398,7 @@ func (t *Task) runInternal(v model.InstalledApp, installMgr *manager.InstallMana
 		Port:             dev.Port,
 		IpaPath:          v.IpaPath,
 		RemoveExtensions: v.RemoveExtensions,
-		RefreshMode:      true,
+		RefreshMode:      shouldUseRefreshMode(v),
 	})
 	if err != nil {
 		installMgr.WriteLog(err.Error())
@@ -414,6 +414,10 @@ func (t *Task) runInternal(v model.InstalledApp, installMgr *manager.InstallMana
 	} else {
 		return nil, fmt.Errorf("install failed with unknown error. %s", installMgr.ErrorLog())
 	}
+}
+
+func shouldUseRefreshMode(v model.InstalledApp) bool {
+	return v.ID != 0
 }
 
 func (t *Task) autoRefreshDeviceApps(device model.Device) error {

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -1,0 +1,20 @@
+package task
+
+import (
+	"testing"
+
+	"github.com/bitxeno/atvloadly/internal/model"
+)
+
+func TestShouldUseRefreshMode(t *testing.T) {
+	newApp := model.InstalledApp{}
+	if shouldUseRefreshMode(newApp) {
+		t.Fatal("new app install should not use refresh mode")
+	}
+
+	existingApp := model.InstalledApp{}
+	existingApp.ID = 1
+	if !shouldUseRefreshMode(existingApp) {
+		t.Fatal("existing app refresh should use refresh mode")
+	}
+}


### PR DESCRIPTION
## Summary
- use refresh mode only for existing saved apps, so queued new installs perform a full sign/install
- pass RSD pairing files to plumesign sign-rsd instead of the unsupported --udid argument
- extend the install timeout to 60 minutes for large tvOS apps

## Testing
- go test ./internal/task ./internal/manager
- manually verified a large tvOS IPA install completed through the RSD install path and produced an IPA with embedded.mobileprovision

Note: go test ./... is not clean on this checkout due to existing unrelated tests: internal/ipa opens /path/to/xxxx.ipa, and the local sandbox blocks internal/notify httptest listener binding.