### PR TITLE
fix(docker): use seccomp unconfined instead of privileged mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ atvloadly is a web service that supports sideloading app on Apple TV. It uses [I
    
    **Docker:**
    ```
-   docker run --privileged -d --name=atvloadly --restart=always -p 5533:80 -v /path/to/mount/dir:/data -v /var/run/dbus:/var/run/dbus -v /var/run/avahi-daemon:/var/run/avahi-daemon bitxeno/atvloadly:latest
+   docker run --security-opt seccomp:unconfined -d --name=atvloadly --restart=always -p 5533:80 -v /path/to/mount/dir:/data -v /var/run/dbus:/var/run/dbus -v /var/run/avahi-daemon:/var/run/avahi-daemon bitxeno/atvloadly:latest
    ```
 
    The `/var/run/dbus` and `/var/run/avahi-daemon` of the host machine need to be shared with the docker container for use.

--- a/README_cn.md
+++ b/README_cn.md
@@ -61,7 +61,7 @@ atvloadly 是一个支持在 AppleTV 上侧载应用的 web 服务。底层通�
    
    **Docker:**
    ```
-   docker run --privileged	-d --name=atvloadly --restart=always -p 5533:80 -v /path/to/mount/dir:/data -v /var/run/dbus:/var/run/dbus -v /var/run/avahi-daemon:/var/run/avahi-daemon  bitxeno/atvloadly:latest
+   docker run --security-opt seccomp:unconfined -d --name=atvloadly --restart=always -p 5533:80 -v /path/to/mount/dir:/data -v /var/run/dbus:/var/run/dbus -v /var/run/avahi-daemon:/var/run/avahi-daemon bitxeno/atvloadly:latest
    ```
    
    宿主机的 `/var/run/dbus` 和`/var/run/avahi-daemon` 需要共享给 docker 容器使用

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     container_name: atvloadly
     hostname: atvloadly
     image: bitxeno/atvloadly:latest
-    privileged: true
+    security_opt:
+      - seccomp:unconfined
     volumes:
       - /etc/atvloadly:/data
       - /var/run/dbus:/var/run/dbus


### PR DESCRIPTION
## Summary
- replace `privileged: true` in `docker-compose.yml` with `security_opt: [seccomp:unconfined]`
- update Docker run examples in `README.md` and `README_cn.md` to use `--security-opt seccomp:unconfined`

## Why
Issue #106 reports that default seccomp blocks required host socket operations while full privileged mode is broader than needed. This change reduces attack surface in the documented/container defaults while keeping the documented functionality path.

Closes #106
