### PR TITLE
Fix PIN input leading zero handling

### DIFF
--- a/web/static/src/page/pair/index.vue
+++ b/web/static/src/page/pair/index.vue
@@ -31,10 +31,15 @@
         <div v-show="!loading" class="flex flex-col gap-y-4">
           <input
             ref="pinInput"
-            type="number"
+            type="text"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            maxlength="6"
+            autocomplete="one-time-code"
             :placeholder="$t('pair.step.pin.placeholder')"
             class="input input-bordered input-primary w-full"
             v-model="pin"
+            @input="onPinInput"
           />
           <button
             class="btn btn-primary"
@@ -111,6 +116,9 @@ export default {
 
       _this.websocketsend(2, _this.pin);
       return;
+    },
+    onPinInput() {
+      this.pin = this.pin.replace(/\D/g, "").slice(0, 6);
     },
     onSubmit() {
       this.$message("submit!");
@@ -208,11 +216,8 @@ export default {
 <script setup>
 import CheckMarkIcon from "@/assets/icons/checkmark.svg";
 </script>
-
-  
-  <style scoped>
+<style scoped>
 .line {
   text-align: center;
 }
 </style>
-  


### PR DESCRIPTION
## Why

Apple TV pairing PINs can start with `0`. The pairing page used a numeric input, which can normalize the value and drop leading zeros before sending the PIN to `plumesign`, causing valid six-digit PINs such as `051243` to be submitted as five digits.

## Approach

Treat the pairing PIN as a fixed-width code instead of a number. This keeps mobile numeric keyboard behavior without browser number parsing.

## How it works

- Changes the pairing PIN input from `type=\"number\"` to `type=\"text\"` with numeric input hints.
- Adds digit-only input sanitization while preserving the PIN string exactly, including leading zeros.
- Caps the field at six digits to match the pairing PIN length expected by the SRP setup.

## Verification

- `npm run build` passed.
- `go test ./...` was run after building frontend assets, but existing unrelated tests fail:
  - `internal/ipa`: `TestParseFile` references missing `/path/to/xxxx.ipa` fixture.
  - `internal/manager`: `TestBuildInstallArgsUsesPairingFileForRSD` fails with `sign-rsd does not accept --udid`.

## Links

- https://github.com/bitxeno/atvloadly/issues/113