### PR TITLE
Disable container core dumps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,37 +77,11 @@ RUN rm -rf /var/lib/lockdown && mkdir -p /data/lockdown && ln -s /data/lockdown 
 
 
 
-# Generate startup script
+# Install startup script
 COPY ./doc/scripts/usbmuxd /etc/init.d/usbmuxd
 RUN chmod +x /etc/init.d/usbmuxd
-RUN printf '#!/bin/sh \n\n\
-
-mkdir -p /data/lockdown \n\
-mkdir -p /data/PlumeImpactor \n\
-mkdir -p /data/PlumeImpactor/pairing_files \n\
-mkdir -p $HOME/.config \n\
-[ ! -e "$HOME/.config/PlumeImpactor" ] && ln -s /data/PlumeImpactor $HOME/.config/PlumeImpactor \n\
-
-if [ -d "/keep/lib" ]; then  \n\
-    rm -rf /data/PlumeImpactor/lib \n\
-    cp -rf /keep/lib /data/PlumeImpactor/lib \n\
-    rm -rf /keep/lib \n\
-fi  \n\
-
-if [ -d "/keep/DeveloperDiskImages" ]; then  \n\
-    rm -rf /data/DeveloperDiskImages \n\
-    cp -rf /keep/DeveloperDiskImages /data/DeveloperDiskImages \n\
-fi  \n\
-
-if [ ! -f "/data/config.yaml" ]; then  \n\
-    cp /keep/config.yaml /data/config.yaml \n\
-fi  \n\
-
-/etc/init.d/usbmuxd start \n\
-
-/usr/bin/%s server -p ${SERVICE_PORT:-80} -c /data/config.yaml  \n\
-\n\
-' ${APP_NAME} >> /entrypoint.sh
+COPY ./doc/scripts/entrypoint.sh /entrypoint.sh
+RUN sed -i "s/__APP_NAME__/${APP_NAME}/g" /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/doc/scripts/entrypoint.sh
+++ b/doc/scripts/entrypoint.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# Disable core dump files for the shell and all child processes.
+ulimit -c 0 || true
+
+mkdir -p /data/lockdown
+mkdir -p /data/PlumeImpactor
+mkdir -p /data/PlumeImpactor/pairing_files
+mkdir -p "$HOME/.config"
+[ ! -e "$HOME/.config/PlumeImpactor" ] && ln -s /data/PlumeImpactor "$HOME/.config/PlumeImpactor"
+
+# Remove core dumps created by previous image versions in the mounted data dir.
+rm -f /data/core
+for core_file in /data/core.[0-9]*; do
+    case "$core_file" in
+        *[!0-9]) continue ;;
+    esac
+    [ -f "$core_file" ] && rm -f "$core_file"
+done
+
+if [ -d "/keep/lib" ]; then
+    rm -rf /data/PlumeImpactor/lib
+    cp -rf /keep/lib /data/PlumeImpactor/lib
+    rm -rf /keep/lib
+fi
+
+if [ -d "/keep/DeveloperDiskImages" ]; then
+    rm -rf /data/DeveloperDiskImages
+    cp -rf /keep/DeveloperDiskImages /data/DeveloperDiskImages
+fi
+
+if [ ! -f "/data/config.yaml" ]; then
+    cp /keep/config.yaml /data/config.yaml
+fi
+
+/etc/init.d/usbmuxd start
+
+exec /usr/bin/__APP_NAME__ server -p "${SERVICE_PORT:-80}" -c /data/config.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     image: bitxeno/atvloadly:latest
     security_opt:
       - seccomp:unconfined
+    ulimits:
+      core: 0
     volumes:
       - /etc/atvloadly:/data
       - /var/run/dbus:/var/run/dbus


### PR DESCRIPTION
## Why

Docker deployments can repeatedly crash native child processes while using `/data` as the working directory, leaving large `core` and `core.<pid>` files in the mounted data volume. This can quickly consume disk space, as reported in issue 116.

## Approach

Move the generated Docker entrypoint into a checked-in shell script so startup behavior is easier to inspect and maintain. Disable core dumps at process startup, and keep the Compose example aligned with an explicit Docker `core: 0` ulimit.

## How it works

The entrypoint runs `ulimit -c 0` before starting `usbmuxd` or the atvloadly server, so the limit is inherited by child processes such as `plumesign`. On startup it also removes legacy top-level `/data/core` and `/data/core.<digits>` files created by older images. The Dockerfile now copies this script into the image and substitutes the build-time app name before marking it executable.

## Links

- https://github.com/bitxeno/atvloadly/issues/116