### PR TITLE
feat(install): support renaming the app via a custom app name

### DIFF
--- a/internal/manager/install_manager.go
+++ b/internal/manager/install_manager.go
@@ -39,6 +39,7 @@ type InstallOptions struct {
 	Port             uint16
 	Account          string
 	IpaPath          string
+	CustomName       string
 	RemoveExtensions bool
 	RefreshMode      bool
 }
@@ -145,11 +146,21 @@ func (t *InstallManager) Start(ctx context.Context, opts InstallOptions) error {
 }
 
 func buildInstallArgs(opts InstallOptions, provisionPath string) []string {
+	var args []string
 	if opts.IP != "" && opts.Port != 0 && opts.UDID != "" {
-		return []string{"sign-rsd", "--apple-id", "--register-and-install", "--output-provision", provisionPath, "--ip", opts.IP, "--port", fmt.Sprintf("%d", opts.Port), "--udid", opts.UDID, "-u", opts.Account, "-p", opts.IpaPath}
+		args = []string{"sign-rsd", "--apple-id", "--register-and-install", "--output-provision", provisionPath, "--ip", opts.IP, "--port", fmt.Sprintf("%d", opts.Port), "--udid", opts.UDID, "-u", opts.Account, "-p", opts.IpaPath}
+	} else {
+		args = []string{"sign", "--apple-id", "--register-and-install", "--output-provision", provisionPath, "--udid", opts.UDID, "-u", opts.Account, "-p", opts.IpaPath}
 	}
 
-	return []string{"sign", "--apple-id", "--register-and-install", "--output-provision", provisionPath, "--udid", opts.UDID, "-u", opts.Account, "-p", opts.IpaPath}
+	// Renames the app on the home screen. The bundle identifier is deliberately
+	// left untouched, so a renamed install still replaces the previous one
+	// instead of registering a second App ID.
+	if opts.CustomName != "" {
+		args = append(args, "--custom-name", opts.CustomName)
+	}
+
+	return args
 }
 
 func (t *InstallManager) GetMobileProvisionPath() string {

--- a/internal/model/installed_app.go
+++ b/internal/model/installed_app.go
@@ -28,6 +28,7 @@ type InstalledApp struct {
 	BundleIdentifier string         `json:"bundle_identifier"`
 	Version          string         `json:"version"`
 	RemoveExtensions bool           `json:"remove_extensions"`
+	CustomName       string         `json:"custom_name,omitempty"`
 	Enabled          bool           `json:"enabled,omitempty"`
 }
 

--- a/internal/service/custom_name_test.go
+++ b/internal/service/custom_name_test.go
@@ -1,0 +1,25 @@
+package service
+
+import "testing"
+
+func TestValidateCustomName(t *testing.T) {
+	ok := []string{"", "Nemio", "My App", "App 2.0", "Media-Center", "影视", "串流 App"}
+	bad := []string{"tv_shelf", " leading", "-dash", "under_score", "emoji 🎬", "a<b>"}
+	for _, n := range ok {
+		if err := ValidateCustomName(n); err != nil {
+			t.Errorf("expected %q valid, got %v", n, err)
+		}
+	}
+	for _, n := range bad {
+		if err := ValidateCustomName(n); err == nil {
+			t.Errorf("expected %q invalid", n)
+		}
+	}
+	long := ""
+	for i := 0; i < 65; i++ {
+		long += "å"
+	}
+	if err := ValidateCustomName(long); err == nil {
+		t.Error("expected 65-rune name invalid")
+	}
+}

--- a/internal/service/db.go
+++ b/internal/service/db.go
@@ -87,6 +87,7 @@ func SaveApp(app model.InstalledApp) (*model.InstalledApp, error) {
 		cur.RefreshedResult = app.RefreshedResult
 		cur.RefreshedError = app.RefreshedError
 		cur.Password = app.Password
+		cur.CustomName = app.CustomName
 
 		// 把 ipa/icon 移动到 ipa 保存目录
 		saveDir := filepath.Join(conf.Config.Server.DataDir, "ipa", fmt.Sprintf("%d", app.ID))
@@ -116,6 +117,7 @@ func SaveApp(app model.InstalledApp) (*model.InstalledApp, error) {
 			"refreshed_result": cur.RefreshedResult,
 			"refreshed_error":  cur.RefreshedError,
 			"password":         cur.Password,
+			"custom_name":      cur.CustomName,
 		}
 		if result := db.Store().Model(&cur).Updates(updateData); result.Error != nil {
 			return nil, result.Error

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"archive/zip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	stdhttp "net/http"
@@ -12,6 +13,7 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/bitxeno/atvloadly/internal/app"
 	"github.com/bitxeno/atvloadly/internal/i18n"
@@ -23,8 +25,31 @@ import (
 
 var (
 	regValidName   = regexp.MustCompile("[^0-9a-zA-Z]+")
+	regCustomName  = regexp.MustCompile(`^[\p{L}\p{N}][\p{L}\p{N} .-]*$`)
 	avahiDaemonPid = "/var/run/avahi-daemon/pid"
 )
+
+// MaxCustomNameLength caps the home-screen name so an over-long value cannot
+// reach Apple's App ID registration.
+const MaxCustomNameLength = 64
+
+// ValidateCustomName checks a user-supplied app name. Apple rejects characters
+// such as underscores in the App ID name derived from the app name (see issue
+// #21, "An invalid value 'tv_shelf' was provided for the parameter
+// 'appIdName'"), so reject them here instead of failing during signing.
+// Letters and digits of any script are allowed, so non-Latin app names work.
+func ValidateCustomName(name string) error {
+	if name == "" {
+		return nil
+	}
+	if utf8.RuneCountInString(name) > MaxCustomNameLength {
+		return fmt.Errorf("app name must be at most %d characters", MaxCustomNameLength)
+	}
+	if !regCustomName.MatchString(name) {
+		return errors.New("app name may only contain letters, numbers, spaces, dots and hyphens, and must start with a letter or number")
+	}
+	return nil
+}
 
 func GetServiceStatus() []model.ServiceStatus {
 	status := []model.ServiceStatus{}

--- a/internal/service/websocket.go
+++ b/internal/service/websocket.go
@@ -49,6 +49,11 @@ func HandleInstallMessage(c *websocket.Conn) {
 				continue
 			}
 
+			if err := ValidateCustomName(v.CustomName); err != nil {
+				_ = c.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("ERROR: %s", err.Error())))
+				continue
+			}
+
 			dev, found := manager.GetDeviceByUDID(v.UDID)
 			if !found || dev == nil {
 				_ = c.WriteMessage(websocket.TextMessage, []byte(fmt.Sprintf("ERROR: device not found for UDID: %s", v.UDID)))
@@ -108,6 +113,7 @@ func runInstallMessage(mgr *manager.WebsocketManager, installMgr *manager.Instal
 		IP:               dev.IP,
 		Port:             dev.Port,
 		IpaPath:          ipaPath,
+		CustomName:       v.CustomName,
 		RemoveExtensions: v.RemoveExtensions,
 		RefreshMode:      false,
 	})

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -361,6 +361,7 @@ func (t *Task) runInternal(v model.InstalledApp, installMgr *manager.InstallMana
 		IP:               dev.IP,
 		Port:             dev.Port,
 		IpaPath:          v.IpaPath,
+		CustomName:       v.CustomName,
 		RemoveExtensions: v.RemoveExtensions,
 		RefreshMode:      shouldUseRefreshMode(v),
 	})

--- a/locales/en.json
+++ b/locales/en.json
@@ -156,6 +156,11 @@
                 "last_used": "Last used",
                 "alt": "For account security, please do not use your primary account for installation."
             },
+            "custom_name": {
+                "label": "App Name:",
+                "placeholder": "Leave blank to keep the app's own name",
+                "tips": "Renames the app on the home screen. The bundle identifier is unchanged, so the app is still replaced on refresh."
+            },
             "password": {
                 "label": "Apple Password:"
             },

--- a/locales/zh_cn.json
+++ b/locales/zh_cn.json
@@ -156,6 +156,11 @@
                 "last_used": "上次使用",
                 "alt": "为了帐号安全，请不要使用常用帐号安装"
             },
+            "custom_name": {
+                "label": "应用名称：",
+                "placeholder": "留空则使用应用自带的名称",
+                "tips": "修改主屏幕上显示的应用名称。Bundle Identifier 保持不变，刷新时仍会覆盖原应用。"
+            },
             "password": {
                 "label": "Apple密码:"
             },

--- a/web/router.go
+++ b/web/router.go
@@ -447,7 +447,12 @@ func route(fi *fiber.App) {
 		account := strings.TrimSpace(c.FormValue("account"))
 		ipaURL := strings.TrimSpace(c.FormValue("url"))
 		deviceID := strings.TrimSpace(c.FormValue("device_id"))
+		customName := strings.TrimSpace(c.FormValue("custom_name"))
 		removeExt := c.FormValue("remove_extensions") == "true"
+
+		if err := service.ValidateCustomName(customName); err != nil {
+			return c.Status(http.StatusOK).JSON(apiError(err.Error()))
+		}
 
 		if account == "" {
 			return c.Status(http.StatusOK).JSON(apiError("account is required"))
@@ -524,6 +529,7 @@ func route(fi *fiber.App) {
 			UDID:             selectedDevice.UDID,
 			Account:          account,
 			Enabled:          true,
+			CustomName:       customName,
 			RemoveExtensions: removeExt,
 		}
 

--- a/web/static/src/page/install/index.vue
+++ b/web/static/src/page/install/index.vue
@@ -106,6 +106,22 @@
             </div>
 
             <div class="form-control">
+              <label class="label">
+                <span class="label-text">{{ $t("install.form.custom_name.label") }}</span>
+                <div class="tooltip" :data-tip="$t('install.form.custom_name.tips')">
+                  <div class="w-4 h-4 text-secondary-content"><HelpIcon /></div>
+                </div>
+              </label>
+              <input
+                type="text"
+                class="input input-bordered w-full"
+                maxlength="64"
+                :placeholder="$t('install.form.custom_name.placeholder')"
+                v-model="form.custom_name"
+              />
+            </div>
+
+            <div class="form-control">
               <label class="label cursor-pointer justify-between items-center gap-x-4">
                 <div class="flex items-center">
                   <span class="label-text">{{
@@ -243,6 +259,7 @@ export default {
       form: {
         account: "",
         password: "",
+        custom_name: "",
         remove_extensions: false,
       },
       log: {
@@ -352,6 +369,7 @@ export default {
             icon: _this.ipa.icon,
             bundle_identifier: _this.ipa.bundle_identifier,
             version: _this.ipa.version,
+            custom_name: _this.form.custom_name.trim(),
             remove_extensions: _this.form.remove_extensions,
         });
       } catch (error) {


### PR DESCRIPTION
## Why

`plumesign` already supports `--custom-name`, but atvloadly never passes it, so there is no way to
change the name an app shows on the tvOS home screen.

This matters most when the sideloaded build coexists with an App Store copy of the same app. Since
signing rewrites the bundle identifier (`com.example.app` → `com.example.app.<TEAM_ID>`), both apps
stay installed side by side with **identical names and identical icons**, and there is no way to
tell them apart on the home screen.

Today the only workaround is to unzip the IPA, rewrite `CFBundleDisplayName` in
`Payload/*.app/Info.plist`, re-zip it, and upload that instead. That works, but it is a lot to ask
of users for a flag the signer already has.

## What

Adds an optional **App Name** field to the install page, plus a `custom_name` parameter on
`POST /api/install` and on the install websocket message.

When set, `--custom-name` is appended to the `plumesign sign` / `sign-rsd` invocation. When empty,
behaviour is byte-for-byte identical to today.

The value is stored on the `InstalledApp` row, so scheduled refreshes and later re-installs of a
newer IPA keep the chosen name without the user re-entering it.

## Deliberate scoping

**`CFBundleIdentifier` is left alone.** `plumesign` also exposes `--custom-identifier` and
`--custom-version`, but exposing the identifier is a different feature with different consequences:
every distinct identifier registers a **new App ID** (consuming one of the free account's 10 per
week) and leaves a second icon behind instead of replacing the first. That deserves its own PR and
its own warning in the UI, so it is not included here.

**Input is validated up front.** Issue #21 (`An invalid value 'tv_shelf' was provided for the
parameter 'appIdName'`) shows that Apple rejects some characters in the App ID name derived from
the app name. `ValidateCustomName` restricts the value to letters, numbers, spaces, dots and
hyphens, must start with a letter or number, max 64 runes — so users get a clear message
immediately instead of a failure deep inside the signing step. Letters and digits are matched with
`\p{L}` / `\p{N}` rather than ASCII classes, so Chinese and other non-Latin names are accepted.

I could not verify how `plumesign` derives `appIdName` from `--custom-name`, since it ships as a
binary. **If it already sanitizes internally, this validation may be stricter than necessary** —
happy to relax or drop it if you know the answer.

## Changes

| File | Change |
|---|---|
| `internal/model/installed_app.go` | `CustomName` field (`custom_name`, omitempty) |
| `internal/manager/install_manager.go` | `InstallOptions.CustomName`; append `--custom-name` in `buildInstallArgs` for both the RSD and USB paths |
| `internal/service/websocket.go` | pass through on the UI install path + validate |
| `internal/task/task.go` | pass through on the scheduled-refresh / API path |
| `internal/service/service.go` | `ValidateCustomName` + `MaxCustomNameLength` |
| `internal/service/db.go` | carry `custom_name` through `SaveApp`'s update path |
| `internal/service/custom_name_test.go` | unit tests for the validator |
| `web/router.go` | read and validate `custom_name` on `POST /api/install` |
| `web/static/src/page/install/index.vue` | optional text input |
| `locales/en.json`, `locales/zh_cn.json` | label, placeholder, tooltip |

107 insertions, 2 deletions. The 2 deletions are `buildInstallArgs` returning a variable instead
of two early returns, so the flag can be appended to either form.

## Testing

Verified end to end against an **Apple TV 4K (AppleTV14,1), tvOS 26.6**, atvloadly on Synology DSM
(Docker, host network), free Apple ID:

- Installed with **App Name = `Nemio`** from an unmodified upstream IPA. Debug log confirms the
  flag reaches the signer, correctly placed and with the value intact:
  ```
  Install Command: plumesign sign-rsd --apple-id --register-and-install --output-provision
    /tmp/embedded.mobileprovision.<n> --ip 192.168.1.16 --port 49152 --udid 00008110-<...>
    -u <account> -p /data/tmp/install_url_<n>.ipa --custom-name Nemio
  ```
- `GET /api/apps` afterwards reports `custom_name: "Nemio"` on the existing row, so the value
  survives the update path and will be reapplied on the next scheduled refresh.
- Rejected as expected: `tv_shelf` (issue #21), `Movie 🎬`, a 65-character name. With the field
  absent, the request falls through to the normal `account is required` error, so the validator
  does not interfere with existing callers.
- The registered App ID stayed `com.stremio.pal.<TEAM_ID>` with no second App ID created, i.e. the
  rename did not consume an extra App ID slot.
- Re-installing over the top replaced the existing app and updated the existing DB row
  (`installed_date` preserved, `expiration_date` advanced) rather than creating a duplicate.
- Left blank → unchanged behaviour, app installs under its own name.
- `go test ./internal/service/ -run TestValidateCustomName` passes, covering CJK names
  (`影视`, `串流 App`), the rejected cases above, and the rune-count boundary.
- Frontend builds clean (`npm run build`); `go build ./...` and `go vet ./...` pass.

## Notes for review

- I did not add a DB migration; gorm's automigrate adds the nullable column. Existing rows get an
  empty `custom_name` and behave exactly as before. I also downgraded back to the released binary
  against the same database afterwards with no ill effects, since the extra column is simply
  unreferenced.
- `SaveApp` copies an explicit whitelist of fields onto an existing row, so `custom_name` had to be
  added there too — without it the name is accepted for the initial install but silently dropped
  on every subsequent one. Worth a look during review in case other newer fields have the same
  gap.
- Happy to split the locale strings differently or reword the tooltip — the zh_cn strings are my
  best effort and would benefit from a native check.